### PR TITLE
Fix wrong popup position for some dialogs

### DIFF
--- a/src/main/java/dev/ambershadow/cogfly/Cogfly.java
+++ b/src/main/java/dev/ambershadow/cogfly/Cogfly.java
@@ -190,10 +190,11 @@ public class Cogfly {
             logger.info("No stored profile save path! Prompting:");
             JDialog prompt = new JDialog(FrameManager.getOrCreate().frame, "Profile Save Path", true);
             prompt.setLayout(new BorderLayout());
-            prompt.setLocationRelativeTo(null);
             prompt.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
             prompt.setResizable(false);
             prompt.setPreferredSize(new Dimension(450, 160));
+            prompt.pack();
+            prompt.setLocationRelativeTo(FrameManager.getOrCreate().frame);
 
             JPanel texts = new JPanel(new BorderLayout());
             JLabel first = new JLabel("You don't have a path on file for saving profiles. ");
@@ -237,6 +238,8 @@ public class Cogfly {
             prompt.setDefaultCloseOperation(JDialog.DO_NOTHING_ON_CLOSE);
             prompt.setResizable(false);
             prompt.setPreferredSize(new Dimension(450, 140));
+            prompt.pack();
+            prompt.setLocationRelativeTo(FrameManager.getOrCreate().frame);
 
             JPanel texts = new JPanel(new BorderLayout());
             JLabel first = new JLabel("You don't have a path on file for your silksong installation. ");

--- a/src/main/java/dev/ambershadow/cogfly/elements/SettingsDialog.java
+++ b/src/main/java/dev/ambershadow/cogfly/elements/SettingsDialog.java
@@ -37,7 +37,6 @@ public class SettingsDialog extends JDialog {
         holder.add(new AutoNameSpacingElement(this));
         holder.add(new UseRelativeTimeElement(this));
         holder.add(new PerProfileGamePathsElement(this));
-//        holder.add(new LaunchWithSteamElement(this));
         holder.add(new ProfileSourcesPanelElement(this));
 
         saveButton = new JButton("Apply & Save");
@@ -50,9 +49,9 @@ public class SettingsDialog extends JDialog {
         panel.add(holder, BorderLayout.NORTH);
         add(panel);
 
-        setLocationRelativeTo(null);
         setDefaultCloseOperation(DISPOSE_ON_CLOSE);
         pack();
+        setLocationRelativeTo(parent);
 
         saveButton.setEnabled(false);
         addWindowListener(new WindowAdapter() {
@@ -189,7 +188,6 @@ public class SettingsDialog extends JDialog {
         Cogfly.settings.scrollingIncrement = queuedScrollIncrement;
         Cogfly.settings.useRelativeTime = queuedRelativeTime;
         Cogfly.settings.profileSpecificPaths = queuedPerProfilePaths;
-//        Cogfly.settings.launchWithSteam = queuedLaunchWithSteam;
 
         if (!queuedProfileSources.equals(initialProfileSources))
             ProfileManager.loadProfiles();
@@ -210,7 +208,6 @@ public class SettingsDialog extends JDialog {
         queuedScrollIncrement = Cogfly.settings.scrollingIncrement;
         queuedRelativeTime = Cogfly.settings.useRelativeTime;
         queuedPerProfilePaths = Cogfly.settings.profileSpecificPaths;
-//        queuedLaunchWithSteam = Cogfly.settings.launchWithSteam;
         initialProfileSources = new ArrayList<>(Cogfly.settings.profileSources);
         initialAutoNameSpacing = Cogfly.settings.modNameSpaces;
         initialBaseGameEnabled = Cogfly.settings.baseGameEnabled;
@@ -220,6 +217,5 @@ public class SettingsDialog extends JDialog {
         initialScrollIncrement = Cogfly.settings.scrollingIncrement;
         initialRelativeTime = Cogfly.settings.useRelativeTime;
         initialPerProfilePaths = Cogfly.settings.profileSpecificPaths;
-//        initialLaunchWithSteam = Cogfly.settings.launchWithSteam;
     }
 }

--- a/src/main/java/dev/ambershadow/cogfly/elements/profiles/ProfileOpenPageCardElement.java
+++ b/src/main/java/dev/ambershadow/cogfly/elements/profiles/ProfileOpenPageCardElement.java
@@ -85,22 +85,12 @@ public class ProfileOpenPageCardElement extends JPanel {
         exportAsId.addActionListener(_ -> {
             String id = ProfileManager.toId(profile);
             Utils.copyString(id);
-            JDialog dialog = new JDialog(FrameManager.getOrCreate().frame);
-            dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
-            dialog.setTitle("Exported as code");
-            dialog.setModal(true);
-            dialog.setResizable(false);
-            dialog.setLocationRelativeTo(null);
-            dialog.setSize(500, 100);
-            JTextArea textArea = new JTextArea("Your code: " + id + " has been copied to your clipboard!");
-            textArea.setEditable(false);
-            textArea.setLineWrap(true);
-            textArea.setWrapStyleWord(true);
-            textArea.setOpaque(false);
-            textArea.setBorder(null);
-            textArea.setFocusable(true);
-            dialog.add(textArea, BorderLayout.CENTER);
-            dialog.setVisible(true);
+            JOptionPane.showMessageDialog(
+                null, 
+                "Your code: " + id + " has been copied to your clipboard!", 
+                "Copied!",
+                JOptionPane.PLAIN_MESSAGE
+            );
         });
 
         JButton exportAsFile = new JButton("Export As File");

--- a/src/main/java/dev/ambershadow/cogfly/loader/ModFetcher.java
+++ b/src/main/java/dev/ambershadow/cogfly/loader/ModFetcher.java
@@ -34,27 +34,13 @@ public class ModFetcher {
         ) {
             content = new String(gzip1.readAllBytes());
         }
-        catch (UnknownHostException unknown){
-            JDialog dialog = new JDialog((Dialog)null, "No internet?");
-            dialog.setIconImage(Assets.icon.getAsImage());
-            dialog.setDefaultCloseOperation(JDialog.DISPOSE_ON_CLOSE);
-            dialog.setLocationRelativeTo(null);
-            JPanel panel = new JPanel(new BorderLayout());
-            panel.setAlignmentX(Component.CENTER_ALIGNMENT);
-            JLabel a = new JLabel("An UnknownHostException was thrown during mod discovery.");
-            JLabel b = new JLabel("Mods will not show.");
-            a.setHorizontalAlignment(SwingConstants.CENTER);
-            b.setHorizontalAlignment(SwingConstants.CENTER);
-            panel.add(a, BorderLayout.NORTH);
-            panel.add(b, BorderLayout.CENTER);
-            JButton button = new JButton("Continue");
-            button.addActionListener(_ -> dialog.dispose());
-            dialog.add(button);
-            dialog.add(panel, BorderLayout.NORTH);
-
-            dialog.setResizable(false);
-            dialog.setSize(350, 100);
-            dialog.setVisible(true);
+        catch (UnknownHostException unknown) {
+            JOptionPane.showMessageDialog(
+                null,
+                "An UnknownHostException was thrown during mod discovery.\nMods will not show",
+                "No Internet?",
+                JOptionPane.WARNING_MESSAGE
+            );
 
             return new ArrayList<>();
         }


### PR DESCRIPTION
Dialogs popup at middle position but at top-left corner. Those dialogs are:
- Settings dialog
- Gamepath-related dialogs
- Some information/warning dialogs, which are No internet dialog, Copied to Clipboard dialog. I used `JOptionPane.showMessageDialog(...)` instead of manually creating one like you did. I think it would be much simpler and nicer

I also removed some of your commented code. Sorry for it ;], I was so uncomfortable to see them.