### PR TITLE
fix #35; require Java 22; slight UI handling tweaks; fix macOS profile creation issue;

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Please submit actual information about the bug experienced. Please also submit y
 If you're just looking for a jar file, it can be found in the release artifacts.
 The latest CI build can be retrieved from the workflow, but building manually is very simple.
 
+***Cogfly requires Java 22 or later to compile.***
 
 Windows:
 To build Cogfly on Windows, you'll need both GCC and G++ in your PATH, as they are invoked to compile the Windows file dialog libraries.

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -8,12 +8,6 @@ group = "dev.ambershadow"
 version = property("version") as String
 
 // Java 22 minimum since since project uses unnamed vars/patterns
-java {
-    toolchain {
-        languageVersion.set(JavaLanguageVersion.of(22))
-    }
-}
-
 tasks.withType<JavaCompile> {
     options.release.set(22)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,21 +1,10 @@
 plugins {
     id("java")
-    id("application")
     id("com.gradleup.shadow") version "9.3.0"
 }
 
 group = "dev.ambershadow"
 version = property("version") as String
-
-// requires Java 22 since since project uses unnamed vars/patterns
-tasks.withType<JavaCompile> {
-    options.release.set(22)
-}
-
-// provides us the 'run' gradlew task
-application {
-    mainClass.set("dev.ambershadow.cogfly.Cogfly")
-}
 
 repositories {
     mavenCentral()
@@ -74,30 +63,18 @@ tasks.register("ver") {
     }
 }
 
+if (System.getProperty("os.name").lowercase().contains("windows")) {
+    tasks.processResources {
+        dependsOn(compileWinFolderPicker, compileTinyFileDialogs)
+    }
+}
+
 tasks.shadowJar {
     archiveBaseName.set("Cogfly")
-    archiveClassifier.set("SHADED") // convention
+    archiveClassifier.set("")
     archiveVersion.set(version.toString())
-
     manifest {
         attributes["Main-Class"] = "dev.ambershadow.cogfly.Cogfly"
         attributes["Implementation-Version"] = version
     }
-}
-
-// satiate the machine... 
-tasks.named("startShadowScripts") {
-    dependsOn(tasks.named("shadowJar"))
-}
-
-tasks.named("startScripts") {
-    dependsOn(tasks.named("shadowJar"))
-}
-
-tasks.named("distTar") {
-    dependsOn(tasks.named("shadowJar"))
-}
-
-tasks.named("distZip") {
-    dependsOn(tasks.named("shadowJar"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,10 +1,27 @@
 plugins {
     id("java")
+    id("application")
     id("com.gradleup.shadow") version "9.3.0"
 }
 
 group = "dev.ambershadow"
 version = property("version") as String
+
+// Java 22 minimum since since project uses unnamed vars/patterns
+java {
+    toolchain {
+        languageVersion.set(JavaLanguageVersion.of(22))
+    }
+}
+
+tasks.withType<JavaCompile> {
+    options.release.set(22)
+}
+
+// provides us the 'run' gradlew task
+application {
+    mainClass.set("dev.ambershadow.cogfly.Cogfly")
+}
 
 repositories {
     mavenCentral()
@@ -63,18 +80,30 @@ tasks.register("ver") {
     }
 }
 
-if (System.getProperty("os.name").lowercase().contains("windows")) {
-    tasks.processResources {
-        dependsOn(compileWinFolderPicker, compileTinyFileDialogs)
-    }
-}
-
 tasks.shadowJar {
     archiveBaseName.set("Cogfly")
-    archiveClassifier.set("")
+    archiveClassifier.set("SHADED") // convention
     archiveVersion.set(version.toString())
+
     manifest {
         attributes["Main-Class"] = "dev.ambershadow.cogfly.Cogfly"
         attributes["Implementation-Version"] = version
     }
+}
+
+// satiate the machine... 
+tasks.named("startShadowScripts") {
+    dependsOn(tasks.named("shadowJar"))
+}
+
+tasks.named("startScripts") {
+    dependsOn(tasks.named("shadowJar"))
+}
+
+tasks.named("distTar") {
+    dependsOn(tasks.named("shadowJar"))
+}
+
+tasks.named("distZip") {
+    dependsOn(tasks.named("shadowJar"))
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
 group = "dev.ambershadow"
 version = property("version") as String
 
-// Java 22 minimum since since project uses unnamed vars/patterns
+// requires Java 22 since since project uses unnamed vars/patterns
 tasks.withType<JavaCompile> {
     options.release.set(22)
 }

--- a/src/main/java/dev/ambershadow/cogfly/Cogfly.java
+++ b/src/main/java/dev/ambershadow/cogfly/Cogfly.java
@@ -373,7 +373,7 @@ public class Cogfly {
                         FrameManager.CogflyPage.PROFILES,
                         FrameManager.getOrCreate().profilesPageButton
                 );
-                ProfilesScreenElement.createPrompt(ProfilesScreenElement.defaultCallback, () -> JOptionPane.showMessageDialog(
+                ProfilesScreenElement.createProfilePrompt(ProfilesScreenElement.defaultCallback, () -> JOptionPane.showMessageDialog(
                         FrameManager.getOrCreate().frame,
                         "Congratulations on creating your first profile! Click on its icon to manage it and install mods!",
                         "Profile Onboarding",

--- a/src/main/java/dev/ambershadow/cogfly/elements/SelectedPageButtonElement.java
+++ b/src/main/java/dev/ambershadow/cogfly/elements/SelectedPageButtonElement.java
@@ -6,14 +6,20 @@ import java.awt.*;
 public class SelectedPageButtonElement extends JButton {
 
     public boolean selected;
+
     public SelectedPageButtonElement(String name) {
         super(name);
+        
+        setFocusPainted(false);
+        setBorderPainted(false);
+        setContentAreaFilled(true);
+        setOpaque(true);
     }
 
     @Override
     protected void paintBorder(Graphics g) {
-        if (selected || isSelected())
-            setBorderPainted(true);
-
+        if (selected || isSelected()) {
+            super.paintBorder(g);
+        }
     }
 }

--- a/src/main/java/dev/ambershadow/cogfly/elements/profiles/ProfileCardElement.java
+++ b/src/main/java/dev/ambershadow/cogfly/elements/profiles/ProfileCardElement.java
@@ -66,13 +66,23 @@ public class ProfileCardElement extends JPanel {
                 }
                 JPanel pages = FrameManager.getOrCreate().getPagePanel();
                 ProfileOpenPageCardElement panel = new ProfileOpenPageCardElement(profile);
+
                 panel.setName(profile.getName());
-                FrameManager.getOrCreate().getPagePanel().add(panel, profile.getName());
+                pages.add(panel, profile.getName());
                 panel.reload();
-                ((CardLayout)pages.getLayout()).show(pages, profile.getName());
+
+                CardLayout layout = (CardLayout) pages.getLayout();
+                layout.show(pages, profile.getName());
+
                 SelectedPageButtonElement button = FrameManager.getOrCreate().getCurrentPageButton();
-                button.setBackground(UIManager.getColor("Button.background"));
-                button.selected = false;
+
+                if (button != null) {
+                    button.setBackground(UIManager.getColor("Button.background"));
+                    button.selected = false;
+                }
+
+                pages.revalidate();
+                pages.repaint();
             }
         };
 
@@ -202,27 +212,36 @@ public class ProfileCardElement extends JPanel {
             // lowkey this jpanel chain sucks but nothing else was working lol
             JPanel e = new JPanel(new BorderLayout());
             JPanel main = new JPanel();
+            
             main.setLayout(new BoxLayout(main, BoxLayout.Y_AXIS));
-            JPanel holder = new JPanel();
+            main.setBorder(BorderFactory.createEmptyBorder(10, 10, 10, 10));
+
+            JPanel holder = new JPanel(new BorderLayout(5, 5));
             holder.add(name, BorderLayout.WEST);
-            holder.add(nameField, BorderLayout.EAST);
-            JPanel extraHolder = new JPanel();
+            holder.add(nameField, BorderLayout.CENTER);
+
+            JPanel extraHolder = new JPanel(new BorderLayout(5, 5));
             extraHolder.add(icon, BorderLayout.WEST);
-            extraHolder.add(button,  BorderLayout.EAST);
+            extraHolder.add(button, BorderLayout.CENTER);
+
             main.add(holder);
+            main.add(Box.createVerticalStrut(8));
             main.add(extraHolder);
             if (Cogfly.settings.profileSpecificPaths) {
-                JPanel holder3 = new JPanel();
+                JPanel holder3 = new JPanel(new BorderLayout(5, 5));
                 holder3.add(pth, BorderLayout.WEST);
-                holder3.add(btn, BorderLayout.EAST);
+                holder3.add(btn, BorderLayout.CENTER);
+                main.add(Box.createVerticalStrut(8));
                 main.add(holder3);
             }
-            main.add(Box.createVerticalStrut(10));
-            e.add(main, BorderLayout.CENTER);
-            e.add(create, BorderLayout.SOUTH);
-            prompt.setSize(new Dimension(500, 180));
-            prompt.setLocationRelativeTo(null);
-            prompt.setContentPane(e);
+
+            JPanel content = new JPanel(new BorderLayout());
+            content.add(main, BorderLayout.CENTER);
+            content.add(create, BorderLayout.SOUTH);
+
+            prompt.setContentPane(content);
+            prompt.pack();
+            prompt.setLocationRelativeTo(FrameManager.getOrCreate().frame);
             prompt.setVisible(true);
         });
 

--- a/src/main/java/dev/ambershadow/cogfly/elements/profiles/ProfileCardElement.java
+++ b/src/main/java/dev/ambershadow/cogfly/elements/profiles/ProfileCardElement.java
@@ -227,7 +227,7 @@ public class ProfileCardElement extends JPanel {
         });
 
         copy = new JButton();
-        copy.addActionListener(_ -> ProfilesScreenElement.createPrompt((name, icn) -> Cogfly.runAsync(() -> {
+        copy.addActionListener(_ -> ProfilesScreenElement.createProfilePrompt((name, icn) -> Cogfly.runAsync(() -> {
             try (Stream<Path> files = Files.walk(profile.getPath())) {
                 Files.createDirectory(Path.of(Cogfly.settings.profileSavePath).resolve(name));
                 Path source = Paths.get(icn);

--- a/src/main/java/dev/ambershadow/cogfly/elements/profiles/ProfilesScreenElement.java
+++ b/src/main/java/dev/ambershadow/cogfly/elements/profiles/ProfilesScreenElement.java
@@ -42,7 +42,7 @@ public class ProfilesScreenElement extends JPanel implements ReloadablePage {
         refreshQueued = true;
     }
 
-    public static void createPrompt(BiConsumer<String, String> consumer, Runnable extra) {
+    public static void createProfilePrompt(BiConsumer<String, String> consumer, Runnable extra) {
         JDialog prompt = new JDialog(FrameManager.getOrCreate().frame);
         prompt.setModal(true);
         prompt.setSize(new Dimension(300, 150));
@@ -162,7 +162,7 @@ public class ProfilesScreenElement extends JPanel implements ReloadablePage {
 
 
         JButton createProfile = new JButton("Create Profile");
-        createProfile.addActionListener(_ -> createPrompt(defaultCallback, () -> {}));
+        createProfile.addActionListener(_ -> createProfilePrompt(defaultCallback, () -> {}));
 
         JButton createShortcut = new JButton("Create Shortcut");
         createShortcut.addActionListener(_ -> {

--- a/src/main/java/dev/ambershadow/cogfly/elements/profiles/ProfilesScreenElement.java
+++ b/src/main/java/dev/ambershadow/cogfly/elements/profiles/ProfilesScreenElement.java
@@ -47,7 +47,6 @@ public class ProfilesScreenElement extends JPanel implements ReloadablePage {
         prompt.setModal(true);
         prompt.setSize(new Dimension(300, 150));
         prompt.setResizable(false);
-        prompt.setLocationRelativeTo(null);
         prompt.setDefaultCloseOperation(WindowConstants.DISPOSE_ON_CLOSE);
         JPanel holder = new JPanel();
         JLabel name = new JLabel("Name: ");
@@ -74,6 +73,9 @@ public class ProfilesScreenElement extends JPanel implements ReloadablePage {
         prompt.add(holder, BorderLayout.NORTH);
         prompt.add(extraHolder, BorderLayout.CENTER);
         prompt.add(create, BorderLayout.SOUTH);
+
+        prompt.pack();
+        prompt.setLocationRelativeTo(FrameManager.getOrCreate().frame);
         prompt.setVisible(true);
     }
     private final JPanel parentPanel;

--- a/src/main/java/dev/ambershadow/cogfly/elements/settings/ManageProfileSourcesDialog.java
+++ b/src/main/java/dev/ambershadow/cogfly/elements/settings/ManageProfileSourcesDialog.java
@@ -65,5 +65,6 @@ public class ManageProfileSourcesDialog extends JDialog {
         buttonWrapper.add(Box.createHorizontalStrut(200));
         buttonWrapper.add(button2, BorderLayout.WEST);
         add(buttonWrapper, BorderLayout.SOUTH);
+        this.pack();
     }
 }

--- a/src/main/java/dev/ambershadow/cogfly/util/GameUtils.java
+++ b/src/main/java/dev/ambershadow/cogfly/util/GameUtils.java
@@ -57,23 +57,27 @@ public class GameUtils {
         if (Files.exists(ver)) {
             oldPackVersion = Files.readString(ver);
         }
-        pack = Cogfly.localDataPath.resolve("BepInExPack");
-        doorstop = Cogfly.localDataPath.resolve("doorstop");
-        if (version.equals(oldPackVersion))
+        Path newPack = Cogfly.localDataPath.resolve("BepInExPack");
+        Path newDoorstop = Cogfly.localDataPath.resolve("doorstop");
+        if (version.equals(oldPackVersion)) {
+            pack = newPack;
+            doorstop = newDoorstop;
             return;
-        Path pack = Cogfly.localDataPath.resolve("bex_pack");
-        FileUtils.downloadAndExtract(packUrl, pack);
-        FileUtils.deleteFolder(pack);
-        Files.move(pack.resolve("BepInExPack"), pack);
-        FileUtils.deleteFolder(pack);
-        FileUtils.deleteFolder(doorstop);
-        Files.createDirectory(doorstop);
-        Files.delete(pack.resolve("changelog.txt"));
-        try (Stream<Path> files = Files.list(pack)) {
+        }
+        Path downloadedPack = Cogfly.localDataPath.resolve("bex_pack");
+        FileUtils.deleteFolder(downloadedPack);
+        FileUtils.downloadAndExtract(packUrl, downloadedPack);
+        FileUtils.deleteFolder(newPack);
+        Files.move(downloadedPack.resolve("BepInExPack"), newPack);
+        FileUtils.deleteFolder(downloadedPack);
+        Files.deleteIfExists(newDoorstop);
+        Files.createDirectory(newDoorstop);
+        Files.deleteIfExists(newPack.resolve("changelog.txt"));
+        try (Stream<Path> files = Files.list(newPack)) {
             files.forEach(file -> {
                 if (!Files.isDirectory(file)) {
                     try {
-                        Files.move(file, doorstop.resolve(file.getFileName()));
+                        Files.move(file, newDoorstop.resolve(file.getFileName()));
                     } catch (IOException e) {
                         throw new RuntimeException(e);
                     }
@@ -81,6 +85,10 @@ public class GameUtils {
             });
         }
         Files.write(ver, version.getBytes());
+
+        // only mark the pack as available after it is actually ready
+        pack = newPack;
+        doorstop = newDoorstop;
     }
 
     private static void downloadDoorstop(Path path) {
@@ -126,7 +134,8 @@ public class GameUtils {
     }
 
     public static void downloadBepInEx(Path path) {
-        if (pack == null) {
+        Cogfly.logger.info("downloadBepInEx({})", path);
+        if (pack == null || !Files.exists(pack.resolve("BepInEx"))) {
             queuedPaths.add(path);
             return;
         }
@@ -134,7 +143,7 @@ public class GameUtils {
         if (Files.exists(bepindll))
             return;
         Cogfly.logger.info("{}", path);
-        try(Stream<Path> files = Files.walk(pack.resolve("BepInEx"))) {
+        try (Stream<Path> files = Files.walk(pack.resolve("BepInEx"))) {
             for (Path file : files.toList()) {
                 Path relative = pack.resolve("BepInEx").relativize(file);
                 Path newF = path.resolve("BepInEx").resolve(relative);
@@ -145,9 +154,10 @@ public class GameUtils {
                     continue;
                 if (Files.isDirectory(file)) {
                     Files.createDirectories(newF);
-                    continue;
+                } else {
+                    Files.createDirectories(newF.getParent());
+                    Files.copy(file, newF);
                 }
-                Files.copy(file, newF);
             }
         } catch (IOException e) {
             throw new RuntimeException(e);

--- a/src/main/java/dev/ambershadow/cogfly/util/swing/FrameManager.java
+++ b/src/main/java/dev/ambershadow/cogfly/util/swing/FrameManager.java
@@ -35,7 +35,6 @@ public class FrameManager {
         frame.setTitle("Cogfly - v" + Cogfly.version);
         frame.setMinimumSize(new Dimension(1200, 750));
         frame.setPreferredSize(new Dimension(1200, 750));
-        frame.setLocation(screenSize.width/2-frame.getWidth()/2,screenSize.height/2-frame.getHeight()/2);
         frame.setIconImage(Assets.icon.getAsImage());
         frame.setLayout(new BorderLayout());
         frame.setDefaultCloseOperation(JFrame.EXIT_ON_CLOSE);
@@ -70,6 +69,9 @@ public class FrameManager {
         topPanel.add(Box.createHorizontalStrut(sidePadding));
         frame.add(pagePanel, BorderLayout.CENTER);
         frame.add(topPanel, BorderLayout.NORTH);
+        frame.pack();
+        frame.setLocation(screenSize.width/2-frame.getWidth()/2,screenSize.height/2-frame.getHeight()/2);
+        frame.setLocationRelativeTo(null);
     }
 
     private SelectedPageButtonElement currentPageButton = null;


### PR DESCRIPTION
Fixes #35.

I won't have access to a Windows machine to test this until Monday (about two days after opening this PR). the changes should work, but they have only been tested on linux (7.1.4-arch1-1) and macOS (latest OS, apple silicon).

If the `build.gradle.kts` changes are not desired, let me know and I can split or revert them.

- added the `application` Gradle plugin and configured Java 22 as the required version (because the project uses unnamed variables/patterns). I updated the README to document this requirement.
- updated the `shadowJar` configuration to coexist with the standard `jar` and `distribution` tasks.
- fixed #35.
- cleaned up some Swing UI behavior by avoiding state changes during painting, adding missing `revalidate()`/`repaint()` calls after dynamic UI updates, and adding a null check when deselecting the current page button.
- renamed `createPrompt` to `createProfilePrompt` for clarity.

[5cb4163](https://github.com/Nix-main/Cogfly/commit/5cb41637ebd010348d017a7136c6dfd5a273b733) - fixed an issue where pack and doorstop were assigned before the BepInEx pack setup had completed. on macOS (observed with self-built jars, ./gradlew run/runShadow, and self-packaged DMG installs), this could cause profiles to be created before required BepInEx files were available. the paths are now only assigned after the pack has been downloaded, extracted, and prepared, preventing incomplete BepInEx installations.