### PR TITLE
avoid crash when tempDir doesn't exist

### DIFF
--- a/src/main/java/dev/ambershadow/cogfly/Cogfly.java
+++ b/src/main/java/dev/ambershadow/cogfly/Cogfly.java
@@ -83,16 +83,19 @@ public class Cogfly {
 
         logger = LoggerFactory.getLogger(Cogfly.class);
         logger.info("Initializing...");
-        try (Stream<Path> stream = Files.walk(tempDir)){
-            for (Path path : stream.toList().reversed()){
-                if (!Files.isDirectory(path)){
-                    Cogfly.logger.info("Cogfly previously failed to install {} for profile {}.", path.getFileName(), path.getParent().getFileName());
-                    failedDownloads.computeIfAbsent(path.getParent().getFileName().toString(), k -> new ArrayList<>()).add(path.getFileName().toString().split("\\d")[0]);
+        try {
+            try (Stream<Path> stream = Files.walk(tempDir)){
+                for (Path path : stream.toList().reversed()){
+                    if (!Files.isDirectory(path)){
+                        Cogfly.logger.info("Cogfly previously failed to install {} for profile {}.", path.getFileName(), path.getParent().getFileName());
+                        failedDownloads.computeIfAbsent(path.getParent().getFileName().toString(), k -> new ArrayList<>()).add(path.getFileName().toString().split("\\d")[0]);
+                    }
+                    Files.delete(path);
                 }
-                Files.delete(path);
             }
+        } catch (IOException e) {
+            Files.createDirectory(tempDir);
         }
-        Files.createDirectory(tempDir);
 
         Thread.setDefaultUncaughtExceptionHandler((thread, throwable) -> {
             logger.error("Uncaught exception in thread {}", thread.getName(), throwable);


### PR DESCRIPTION
errors in the try block in Cogfly.java crash the entire app, so I surrounded it with another try-catch block.